### PR TITLE
Update links to newer projects

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,57 +47,63 @@
         <div id="animated_div" class="text-center text-nowrap">
             <img src="/profile.png" alt="Jon Morgan" id="animated_image"/>
         </div>
-        <div
-            role="button"
+        <a
+            href="https://www.linkedin.com/in/jon-p-morgan"
+            target="_blank"
+            rel="noopener noreferrer"
             id="linear"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://www.linkedin.com/in/jon-p-morgan'"
         >
             LinkedIn Profile
-        </div>
-        <div
-            role="button"
+        </a>
+        <a
+            href="https://github.com/why-pengo"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease-out"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://github.com/why-pengo'"
         >
             Github Overview
-        </div>
+        </a>
         <div id="ease-in" class="links m-2 p-1 text-nowrap">
             <img src="/separator.svg" class="separator" alt="separator"/>
         </div>
-        <div
-            role="button"
+        <a
+            href="https://why-pengo.github.io/angular-sudoku3/"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://why-pengo.github.io/angular-sudoku2/'"
         >
-            Sudoku (Angular v18)
-        </div>
-        <div
-            role="button"
+            Sudoku (Angular v21)
+        </a>
+        <a
+            href="https://github.com/why-pengo/daglint"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease-in-out"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://github.com/why-pengo/sprinkler'"
         >
-            Sprinkler Control (Python)
-        </div>
-        <div
-            role="button"
+            Daglint
+        </a>
+        <a
+            href="https://github.com/why-pengo/sprinkler"
+            target="_blank"
+            rel="noopener noreferrer"
             id="linear2"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://github.com/why-pengo/threejs-playground'"
         >
-            Three.js Playground (WebGl)
-        </div>
-        <div
-            role="button"
+            Sprinkler Controller
+        </a>
+        <a
+            href="https://why-pengo.github.io/threejs-playground/"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease-out2"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://why-pengo.github.io/apple-catcher-Phaser-Typescript/'"
         >
-            Phaser - Apple Catch Game
-        </div>
+            Three.js Playground (WebGl)
+        </a>
         <div class="m-3">
             <div class="footer">Jon Morgan</div>
             <div class="footer">Remote Developer</div>

--- a/index.html
+++ b/index.html
@@ -47,57 +47,63 @@
         <div id="animated_div" class="text-center text-nowrap">
             <img src="/profile.png" alt="Jon Morgan" id="animated_image"/>
         </div>
-        <div
-            role="button"
+        <a
+            href="https://www.linkedin.com/in/jon-p-morgan"
+            target="_blank"
+            rel="noopener noreferrer"
             id="linear"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://www.linkedin.com/in/jon-p-morgan'"
         >
             LinkedIn Profile
-        </div>
-        <div
-            role="button"
+        </a>
+        <a
+            href="https://github.com/why-pengo"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease-out"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://github.com/why-pengo'"
         >
             Github Overview
-        </div>
+        </a>
         <div id="ease-in" class="links m-2 p-1 text-nowrap">
             <img src="/separator.svg" class="separator" alt="separator"/>
         </div>
-        <div
-            role="button"
+        <a
+            href="https://why-pengo.github.io/angular-sudoku3/"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://why-pengo.github.io/angular-sudoku2/'"
         >
-            Sudoku (Angular v18)
-        </div>
-        <div
-            role="button"
+            Sudoku (Angular v21)
+        </a>
+        <a
+            href="https://github.com/why-pengo/daglint"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease-in-out"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://github.com/why-pengo/sprinkler'"
         >
-            Sprinkler Control (Python)
-        </div>
-        <div
-            role="button"
+            Daglint
+        </a>
+        <a
+            href="https://github.com/why-pengo/sprinkler"
+            target="_blank"
+            rel="noopener noreferrer"
             id="linear2"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://github.com/why-pengo/threejs-playground'"
         >
-            Three.js Playground (WebGl)
-        </div>
-        <div
-            role="button"
+            Sprinkler Controller
+        </a>
+        <a
+            href="https://why-pengo.github.io/threejs-playground/"
+            target="_blank"
+            rel="noopener noreferrer"
             id="ease-out2"
             class="links m-2 p-1 text-nowrap"
-            onclick="location.href='https://why-pengo.github.io/apple-catcher-Phaser-Typescript/'"
         >
-            Phaser - Apple Catch Game
-        </div>
+            Three.js Playground (WebGl)
+        </a>
         <div class="m-3">
             <div class="footer">Jon Morgan</div>
             <div class="footer">Remote Developer</div>


### PR DESCRIPTION
This pull request updates the main navigation links on both `index.html` and `docs/index.html` to improve accessibility and user experience. The previous clickable `div` elements with JavaScript-based navigation have been replaced with semantic `<a>` anchor tags that use standard `href` attributes. This change ensures that links open in new tabs, improves accessibility for screen readers, and follows best practices for external links.

**Navigation and accessibility improvements:**

* Replaced all navigation `div` elements with semantic `<a>` tags, using `href`, `target="_blank"`, and `rel="noopener noreferrer"` for external links to enhance accessibility and security. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L50-R106) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL50-R106)
* Updated project links and labels to reflect current versions and repositories, such as changing "Sudoku (Angular v18)" to "Sudoku (Angular v21)" and updating project names for clarity. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L50-R106) [[2]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL50-R106)