### PR TITLE
add ollama rag playground

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,13 +96,13 @@
             Sprinkler Controller
         </a>
         <a
-            href="https://why-pengo.github.io/threejs-playground/"
+            href="https://github.com/why-pengo/llamaIndexPlayground"
             target="_blank"
             rel="noopener noreferrer"
             id="ease-out2"
             class="links m-2 p-1 text-nowrap"
         >
-            Three.js Playground (WebGl)
+            Local LLM RAG Playground
         </a>
         <div class="m-3">
             <div class="footer">Jon Morgan</div>

--- a/index.html
+++ b/index.html
@@ -96,13 +96,13 @@
             Sprinkler Controller
         </a>
         <a
-            href="https://why-pengo.github.io/threejs-playground/"
+            href="https://github.com/why-pengo/llamaIndexPlayground"
             target="_blank"
             rel="noopener noreferrer"
             id="ease-out2"
             class="links m-2 p-1 text-nowrap"
         >
-            Three.js Playground (WebGl)
+            Local LLM RAG Playground
         </a>
         <div class="m-3">
             <div class="footer">Jon Morgan</div>


### PR DESCRIPTION
This pull request updates the external link in both the `docs/index.html` and `index.html` files to point to a new project, and changes the displayed link text accordingly.

Link updates:

* Changed the link URL from the Three.js Playground to the LlamaIndex Playground GitHub repository in both `docs/index.html` and `index.html`. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL99-R105) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L99-R105)
* Updated the link text from "Three.js Playground (WebGl)" to "Local LLM RAG Playground" in both files. [[1]](diffhunk://#diff-b04b38d4e36f7a7171aeb211bf933eaf36d41d9866ebbc3639f673f84dc350aeL99-R105) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L99-R105)