### PR TITLE
fix(ci): bump Node to 22 — pnpm 11.3 requires node:sqlite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.13'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "packageManager": "pnpm@11.3.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
The deploy run that fired after #11 merged failed at **Setup Node**:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

pnpm 11.3 uses Node's built-in `node:sqlite` for its store cache (added in Node 22.5 / stable in 22.13). The CI workflow was still pinned to Node 20, so `setup-node` succeeded but the post-install `pnpm store path` step inside the same action exited 1.

Local was fine because corepack picked up Node 24.

## Fix
- `.github/workflows/deploy.yml`: `node-version: '20'` → `'22'`
- `package.json` `engines.node`: `>=20.0.0` → `>=22.13.0` (so a future install surfaces the mismatch immediately instead of mid-CI)

## Meta
This slipped through because **PR CI doesn't run on this repo** — the `deploy.yml` workflow only triggers on `push: branches: main`. Worth a follow-up to add a `pull_request` trigger that runs lint + type-check + tests + build (without the deploy step), so a stack mismatch like this gets caught pre-merge. Out of scope for this hotfix.

## Test plan
- [x] `make ci` green locally
- [ ] Post-merge deploy succeeds and live site at https://why-pengo.github.io/ reflects Direction A

🤖 Generated with [Claude Code](https://claude.com/claude-code)